### PR TITLE
在执行ShowMobaXterm.py时出现TypeError: DecryptPassword() takes 2 positional arguments but 4 were given错误时，请将第 232 与 231 行的   删除, 如果有中文编码，可以将 encode('ansi') => d…

### DIFF
--- a/python3/ShowMobaXterm.py
+++ b/python3/ShowMobaXterm.py
@@ -170,7 +170,7 @@ def WinRegistryReadValue(Root, SubKey: str, ValueName: str, ExpectValueType: int
 
 if len(sys.argv) == 2:
     cipher = MobaXtermCryptoSafe(
-        sys.argv[1].encode('ansi')
+        sys.argv[1].encode("utf8","ignore")
     )
 else:
     Value, ValueType = winreg.QueryValueEx(
@@ -182,9 +182,9 @@ else:
     ); assert(ValueType == winreg.REG_SZ)
 
     cipher = MobaXtermCrypto(
-        platform.node().encode('ansi'), 
-        os.getlogin().encode('ansi'), 
-        Value.encode('ansi')
+        platform.node().encode("utf8","ignore"), 
+        os.getlogin().encode("utf8","ignore"), 
+        Value.encode("utf8","ignore")
     )
 
 try:
@@ -201,7 +201,7 @@ try:
 
             CredentialPassword = cipher.DecryptCredential(
                 CredentialPassword
-            ).decode('ansi')
+            ).decode("utf8","ignore")
 
             print('[*] Name:     %s' % ValueName)
             print('[*] Username: %s' % CredentialUsername)
@@ -227,10 +227,8 @@ try:
                 ConnUsername = ConnUsername.split(':')[-1]
             
             ConnPassword = cipher.DecryptPassword(
-                Value, 
-                ConnHostname.encode('ansi'), 
-                ConnUsername.encode('ansi')
-            ).decode('ansi')
+                Value
+            ).decode("utf8","ignore")
 
             print('[*] Name:     %s' % ValueName)
             print('[*] Password: %s' % ConnPassword)


### PR DESCRIPTION
温馨提示：如果在执行 `python ShowMobaXterm.py weiyigeek` 出现如下错误时，请将第 232 与 231 行的  ` ConnHostname.encode('ansi'),  ConnUsername.encode('ansi') ` 删除。
```bash
-------------------Passwords--------------------
Traceback (most recent call last):
  File "ShowMobaXterm.py", line 232, in <module>
    ConnUsername.encode('ansi')
TypeError: DecryptPassword() takes 2 positional arguments but 4 were given
```

解决办法：
```bash
# ShowMobaXterm.py 中的 229 行
ConnPassword = cipher.DecryptPassword(
  Value
).decode("utf8","ignore")

# 如果有中文编码
encode('ansi') => decode("utf8","ignore")
```